### PR TITLE
Open id clients

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,17 @@
-jobs:
-    include:
-        - name: Testing
-        language: python
-        python:
-            - '3.6'
-            - '3.7'
-            - '3.8'
-        install:
-            - pip install -r requirements.txt
-        script:
-            - python3 -m pytest
-
-        - name: Coverage report
-        python:
-            - '3.6'
-        install:
-            - pip install -r requirements.txt
-        script:
-            - python3 -m pytest --cov-report term --cov=ldaphelper tests/
-        after_success:
-            - codecov
-
-        - name: pypi deploy
-        deploy:
-            provider: pypi
-            username: "__token__"
-            password:
-                secure: G8FYuceEZWXhhscVQjktfwEKZBFgTTkksRaL5FIVcCJDtPkIgl9D/uLLc7LYWFhylkIVGg8D2kF4+PHKNDspb/jjLytEvHxm89unoGUxrY2vgcsX10toxdQpIOTNXlvHRxFmVyTq0JWlkm9zT8KPVHBrLs6zX0mmzkPb/DTNb/L+zR0vd8zBFV+h6MgTaOk9Bhn3X9AATlI1NFR5TPtCapYrcq5fFRf8RVzBSlym+NTLLG5Rl4mmPBGHPZjiT9azYsJxNG5ceSxoHg88JNmxT492PsQiGL6PKm+3lzAPKWoZKwt0CkhHqiSLzl9VGkM7IFGUIWbeRK24HTpSYqytlWMZmG5113HNGbmGa/ejElntVVmF0LhpY/VWq5CZgPIZ6PaijFqsoOtp7U2epEH7Z5v4vBDc4agqeXV1GIy/9s27tDpdHJjgYoYWf8DTQ9wGAD5FbEKK+JwH4Vmq13xyNo4+tRNKtqLTfcXhilRZ7unUx+kotIGnMtzSznuh8+SmtvWsW1eFSU4cERe7PYQ/51o9Mt6UzAQe5P8YQjwcsmoPgOJ75oibT0TCbYEXKgGxENCxlm2RfON2TlRnmzxzh7xYbnEaLWoeqzXC8+y54antRDU9JZPF7oislKQAGiQcJcCZjfPRWc/KjjQ4ihD8Fre5VAyyPbv8+rABik50Jtk=
-
+language: python
+python:
+- '3.6'
+install:
+- pip install -r requirements.txt
+script:
+- python3 -m pytest
+- python3 -m pytest --cov-report term --cov=ldaphelper tests/
+after_success:
+- codecov
+deploy:
+    provider: pypi
+    username: "__token__"
+    password:
+        secure: G8FYuceEZWXhhscVQjktfwEKZBFgTTkksRaL5FIVcCJDtPkIgl9D/uLLc7LYWFhylkIVGg8D2kF4+PHKNDspb/jjLytEvHxm89unoGUxrY2vgcsX10toxdQpIOTNXlvHRxFmVyTq0JWlkm9zT8KPVHBrLs6zX0mmzkPb/DTNb/L+zR0vd8zBFV+h6MgTaOk9Bhn3X9AATlI1NFR5TPtCapYrcq5fFRf8RVzBSlym+NTLLG5Rl4mmPBGHPZjiT9azYsJxNG5ceSxoHg88JNmxT492PsQiGL6PKm+3lzAPKWoZKwt0CkhHqiSLzl9VGkM7IFGUIWbeRK24HTpSYqytlWMZmG5113HNGbmGa/ejElntVVmF0LhpY/VWq5CZgPIZ6PaijFqsoOtp7U2epEH7Z5v4vBDc4agqeXV1GIy/9s27tDpdHJjgYoYWf8DTQ9wGAD5FbEKK+JwH4Vmq13xyNo4+tRNKtqLTfcXhilRZ7unUx+kotIGnMtzSznuh8+SmtvWsW1eFSU4cERe7PYQ/51o9Mt6UzAQe5P8YQjwcsmoPgOJ75oibT0TCbYEXKgGxENCxlm2RfON2TlRnmzxzh7xYbnEaLWoeqzXC8+y54antRDU9JZPF7oislKQAGiQcJcCZjfPRWc/KjjQ4ihD8Fre5VAyyPbv8+rABik50Jtk=
+    on:
+        tags: true

--- a/README.md
+++ b/README.md
@@ -3,3 +3,24 @@
 
 
 Wanna try to make it a little easier
+
+```python
+from ldaphelper import LdapConnection(), User
+
+user = 'cn=directory manager'
+password = 'amazingpassword'
+
+con = LdapConnection(user,password)
+ldp_user = User(con)
+
+user = {
+    "uuid" : "johndoe",
+    "password" : "strongpassword,
+    "mail" : "john.doe@ldaphelper.org",
+    "givenName" : "John",
+    "sn" : "Doe"
+}
+
+added_user = ldp_user.add_user(user)
+
+```

--- a/ldaphelper/__init__.py
+++ b/ldaphelper/__init__.py
@@ -1,4 +1,5 @@
 from .ldapconnector import LdapConnector
 from .passport import Passport
 from .trust_relationships import TrustRelationships
+from .op import Op
 

--- a/ldaphelper/__init__.py
+++ b/ldaphelper/__init__.py
@@ -2,4 +2,3 @@ from .ldapconnector import LdapConnector
 from .passport import Passport
 from .trust_relationships import TrustRelationships
 from .op import Op
-

--- a/ldaphelper/ldapconnector.py
+++ b/ldaphelper/ldapconnector.py
@@ -5,6 +5,9 @@ import string
 from .helper import get_random_inum
 
 class LdapConnector():
+    searchScope = None
+    connect = None
+
     def __init__(self,login,password):
         self.ldap_login = login
         self.password = password

--- a/ldaphelper/ldapconnector.py
+++ b/ldaphelper/ldapconnector.py
@@ -5,6 +5,7 @@ import ldap.modlist as modlist
 class LdapConnector:
     searchScope = None
     connect = None
+
     def __init__(self, login, password):
         self.ldap_login = login
         self.password = password

--- a/ldaphelper/ldapconnector.py
+++ b/ldaphelper/ldapconnector.py
@@ -72,7 +72,7 @@ class LdapConnector:
         attrs["gluuStatus"] = "active".encode()
 
         ldif = modlist.addModlist(attrs)
-
+        modlist.addModlist()
         dn = "inum=%s,ou=people,o=gluu" % attrs["inum"].decode()
 
         self.connect.add_s(dn, ldif)

--- a/ldaphelper/ldapconnector.py
+++ b/ldaphelper/ldapconnector.py
@@ -4,32 +4,31 @@ import random
 import string
 from .helper import get_random_inum
 
-class LdapConnector():
+
+class LdapConnector:
     searchScope = None
     connect = None
 
-    def __init__(self,login,password):
+    def __init__(self, login, password):
         self.ldap_login = login
         self.password = password
         self.baseDN = "o=gluu"
         self.searchScope = ldap.SCOPE_SUBTREE
         self.open_connection()
 
-
     def open_connection(self):
         """Open connection with ldap server as self.connect"""
-        ldap.set_option(ldap.OPT_X_TLS_REQUIRE_CERT,ldap.OPT_X_TLS_NEVER)
+        ldap.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_NEVER)
         self.connect = ldap.initialize("ldaps://localhost:1636")
         self.connect.set_option(ldap.OPT_DEBUG_LEVEL, 255)
         self.connect.protocol_version = ldap.VERSION2
-        self.connect.simple_bind_s(self.ldap_login,self.password)
-
+        self.connect.simple_bind_s(self.ldap_login, self.password)
 
     def close_connection(self):
         """closes connection with ldap server"""
         self.connect.unbind_s()
 
-    def get_user_by_uid(self,uid):
+    def get_user_by_uid(self, uid):
         """[Return complete user from server]
 
         Args:
@@ -38,14 +37,16 @@ class LdapConnector():
         Returns:
             [class 'tuple']: [(dn, attrs)]
         """
-        user = self.connect.search_s(self.baseDN,self.searchScope,'uid=%s' % uid,[
-            'objectClass','mail','givenName','sn','uid','inum'
-            ])
+        user = self.connect.search_s(
+            self.baseDN,
+            self.searchScope,
+            "uid=%s" % uid,
+            ["objectClass", "mail", "givenName", "sn", "uid", "inum"],
+        )
         # user = self.connect.search_s(self.baseDN,self.searchScope,'uid=%s' % uid)
         return user[0]
 
-
-    def create_user(self,uid,password,mail,givenName,sn):
+    def create_user(self, uid, password, mail, givenName, sn):
         """creates user on server and returns created user
 
         Args:
@@ -59,21 +60,25 @@ class LdapConnector():
             [type]: [description]
         """
         attrs = {}
-        attrs['objectClass'] = ['top'.encode('utf-8'), 'gluuCustomPerson'.encode('utf-8'), 'gluuPerson'.encode('utf-8')]
-        attrs['mail'] = mail.encode()
-        attrs['givenName'] = givenName.encode()
-        attrs['sn'] = sn.encode()
-        attrs['uid'] = uid.encode()
-        attrs['userPassword'] = password.encode()
-        attrs['inum'] = self.get_random_inum().encode()
-        attrs['displayName'] = ('%s %s' % (givenName, sn)).encode()
-        attrs['gluuStatus'] = 'active'.encode()
+        attrs["objectClass"] = [
+            "top".encode("utf-8"),
+            "gluuCustomPerson".encode("utf-8"),
+            "gluuPerson".encode("utf-8"),
+        ]
+        attrs["mail"] = mail.encode()
+        attrs["givenName"] = givenName.encode()
+        attrs["sn"] = sn.encode()
+        attrs["uid"] = uid.encode()
+        attrs["userPassword"] = password.encode()
+        attrs["inum"] = self.get_random_inum().encode()
+        attrs["displayName"] = ("%s %s" % (givenName, sn)).encode()
+        attrs["gluuStatus"] = "active".encode()
 
         ldif = modlist.addModlist(attrs)
 
-        dn = 'inum=%s,ou=people,o=gluu' % attrs['inum'].decode()
+        dn = "inum=%s,ou=people,o=gluu" % attrs["inum"].decode()
 
-        self.connect.add_s(dn,ldif)
+        self.connect.add_s(dn, ldif)
         generated_user = self.get_user_by_uid(uid)
 
         return generated_user
@@ -88,12 +93,9 @@ class LdapConnector():
     #     fake_inum = ''.join((random.choice(letters_and_digits) for i in range(30)))
     #     return fake_inum
 
-    def delete_user(self,inum: str):
-        dn = 'inum=%s,ou=people,o=gluu' % inum
+    def delete_user(self, inum: str):
+        dn = "inum=%s,ou=people,o=gluu" % inum
         self.connect.delete_s(dn)
-
-
-
 
 
 # zero = 'inum=76bc7475-1bbe-4677-9496-3bee197a9ccd,ou=people,o=gluu'
@@ -119,7 +121,7 @@ class LdapConnector():
 # print('-------------------------------')
 # print()
 # print(connect.search_s(baseDN,searchScope,'displayName=josephdoe2'))
-#connect.search(baseDN,searchScope,)
+# connect.search(baseDN,searchScope,)
 # connect.unbind_s()
 # except ldap.LDAPError e:
 #     print("LDAP ERROR!! " + e)

--- a/ldaphelper/ldapconnector.py
+++ b/ldaphelper/ldapconnector.py
@@ -1,8 +1,5 @@
 import ldap
 import ldap.modlist as modlist
-import random
-import string
-from .helper import get_random_inum
 
 
 class LdapConnector:

--- a/ldaphelper/op.py
+++ b/ldaphelper/op.py
@@ -1,0 +1,12 @@
+import ldaphelper
+
+class Op:
+    connection = None
+    dn = 'ou=clients,o=gluu'
+    def __init__(self, connection: ldaphelper.LdapConnector):
+        self.connection = connection
+
+    def get_op_by_display_name(self,displayName: str):
+        op_client = self.connection.connect.search_s(
+            self.dn,self.connection.searchScope,'displayName=%s' % displayName)
+        return op_client[0]

--- a/ldaphelper/op.py
+++ b/ldaphelper/op.py
@@ -24,64 +24,68 @@ class Op:
             "displayName=%s" % displayName)
         return op_client[0]
 
-    def add_op(self, displayName: str,
-            oxAuthLogoutSessionRequired: bool,
-            oxAuthTrustedClient: bool,
-            oxAuthResponseType: str,
-            oxAuthTokenEndpointAuthMethod: str,
-            oxAuthRequireAuthTime: bool,
-            oxAccessTokenAsJwt: bool,
-            oxPersistClientAuthorizations: bool,
-            oxAuthGrantType: str,
-            oxAttributes: str,
-            oxAuthAppType: str,
-            oxIncludeClaimsInIdToken: bool,
-            oxRptAsJwt: bool,
-            oxAuthClientSecret: str,
-            oxAuthSubjectType: str,
-            oxDisabled: bool = False,
-            ):
+    def add_op(
+        self,
+        displayName: str,
+        oxAuthLogoutSessionRequired: bool,
+        oxAuthTrustedClient: bool,
+        oxAuthResponseType: str,
+        oxAuthTokenEndpointAuthMethod: str,
+        oxAuthRequireAuthTime: bool,
+        oxAccessTokenAsJwt: bool,
+        oxPersistClientAuthorizations: bool,
+        oxAuthGrantType: str,
+        oxAttributes: str,
+        oxAuthAppType: str,
+        oxIncludeClaimsInIdToken: bool,
+        oxRptAsJwt: bool,
+        oxAuthClientSecret: str,
+        oxAuthSubjectType: str,
+        oxDisabled: bool = False,
+    ):
 
         # set all attributes, boolean ones lowercase
         attrs = {}
-        attrs['displayName'] = str(displayName).encode()
-        attrs['oxAuthLogoutSessionRequired'] = str(oxAuthLogoutSessionRequired).encode().lower()
-        attrs['oxAuthTrustedClient'] = str(oxAuthTrustedClient).encode().lower()
-        attrs['oxAuthResponseType'] = str(oxAuthResponseType).encode()
-        attrs['oxAuthTokenEndpointAuthMethod'] = str(oxAuthTokenEndpointAuthMethod).encode()
-        attrs['oxAuthRequireAuthTime'] = str(oxAuthRequireAuthTime).encode().lower()
-        attrs['oxAccessTokenAsJwt'] = str(oxAccessTokenAsJwt).encode().lower()
-        attrs['oxPersistClientAuthorizations'] = str(oxPersistClientAuthorizations).encode().lower()
-        attrs['oxAuthGrantType'] = str(oxAuthGrantType).encode()
-        attrs['oxAttributes'] = str(oxAttributes).encode()
-        attrs['oxAuthAppType'] = str(oxAuthAppType).encode()
-        attrs['oxIncludeClaimsInIdToken'] = str(oxIncludeClaimsInIdToken).encode().lower()
-        attrs['oxRptAsJwt'] = str(oxRptAsJwt).encode().lower()
-        attrs['oxAuthClientSecret'] = str(oxAuthClientSecret).encode()
-        attrs['oxAuthSubjectType'] = str(oxAuthSubjectType).encode()
-        attrs['oxDisabled'] = str(oxDisabled).encode().lower()
+        attrs["displayName"] = str(displayName).encode()
+        attrs["oxAuthLogoutSessionRequired"] = (
+            str(oxAuthLogoutSessionRequired).encode().lower())
+        attrs["oxAuthTrustedClient"] = str(
+            oxAuthTrustedClient).encode().lower()
+        attrs["oxAuthResponseType"] = str(oxAuthResponseType).encode()
+        attrs["oxAuthTokenEndpointAuthMethod"] = str(
+            oxAuthTokenEndpointAuthMethod).encode()
+        attrs["oxAuthRequireAuthTime"] = str(
+            oxAuthRequireAuthTime).encode().lower()
+        attrs["oxAccessTokenAsJwt"] = str(oxAccessTokenAsJwt).encode().lower()
+        attrs["oxPersistClientAuthorizations"] = (
+            str(oxPersistClientAuthorizations).encode().lower())
+        attrs["oxAuthGrantType"] = str(oxAuthGrantType).encode()
+        attrs["oxAttributes"] = str(oxAttributes).encode()
+        attrs["oxAuthAppType"] = str(oxAuthAppType).encode()
+        attrs["oxIncludeClaimsInIdToken"] = (
+            str(oxIncludeClaimsInIdToken).encode().lower())
+        attrs["oxRptAsJwt"] = str(oxRptAsJwt).encode().lower()
+        attrs["oxAuthClientSecret"] = str(oxAuthClientSecret).encode()
+        attrs["oxAuthSubjectType"] = str(oxAuthSubjectType).encode()
+        attrs["oxDisabled"] = str(oxDisabled).encode().lower()
 
-
-
-        static_attrs = {"objectClass": ["top".encode(), "oxAuthClient".encode()],
-        "oxAuthScope": [
-            "inum=F0C4,ou=scopes,o=gluu".encode(),
-            "inum=C4F5,ou=scopes,o=gluu".encode(),
-        ],
-        "inum": "w124asdgggAGs".encode()
+        static_attrs = {
+            "objectClass": ["top".encode(), "oxAuthClient".encode()],
+            "oxAuthScope": [
+                "inum=F0C4,ou=scopes,o=gluu".encode(),
+                "inum=C4F5,ou=scopes,o=gluu".encode(),
+            ],
+            "inum":
+            "w124asdgggAGs".encode(),
         }
 
         attrs.update(static_attrs)
         all_attrs = attrs
 
-        new_dn = "inum=%s,%s" % (static_attrs['inum'].decode(),self.dn)
+        new_dn = "inum=%s,%s" % (static_attrs["inum"].decode(), self.dn)
         # create modification list
         ldif = modlist.addModlist(all_attrs)
 
-
         self.connection.connect.add_s(new_dn, ldif)
-        created_op = self.get_op_by_display_name(attrs['displayName'].decode())
+        created_op = self.get_op_by_display_name(attrs["displayName"].decode())
         return created_op
-
-
-

--- a/ldaphelper/op.py
+++ b/ldaphelper/op.py
@@ -1,6 +1,5 @@
 import ldaphelper
 from ldaphelper.ldapconnector import modlist
-import json
 
 
 class Op:

--- a/ldaphelper/op.py
+++ b/ldaphelper/op.py
@@ -1,4 +1,6 @@
 import ldaphelper
+from ldaphelper.ldapconnector import modlist
+import json
 
 
 class Op:
@@ -9,8 +11,77 @@ class Op:
         self.connection = connection
 
     def get_op_by_display_name(self, displayName: str):
+        """[Gets Open Id by display name]
+
+        Args:
+            displayName (str): [OP display name ]
+
+        Returns:
+            [tuple]: [returns tupple containing dn and attrs]
+        """
         op_client = self.connection.connect.search_s(
             self.dn, self.connection.searchScope,
             "displayName=%s" % displayName)
-        # import ipdb; ipdb.set_trace()
         return op_client[0]
+
+    def add_op(self, displayName: str,
+            oxAuthLogoutSessionRequired: bool,
+            oxAuthTrustedClient: bool,
+            oxAuthResponseType: str,
+            oxAuthTokenEndpointAuthMethod: str,
+            oxAuthRequireAuthTime: bool,
+            oxAccessTokenAsJwt: bool,
+            oxPersistClientAuthorizations: bool,
+            oxAuthGrantType: str,
+            oxAttributes: str,
+            oxAuthAppType: str,
+            oxIncludeClaimsInIdToken: bool,
+            oxRptAsJwt: bool,
+            oxAuthClientSecret: str,
+            oxAuthSubjectType: str,
+            oxDisabled: bool = False,
+            ):
+
+        # set all attributes, boolean ones lowercase
+        attrs = {}
+        attrs['displayName'] = str(displayName).encode()
+        attrs['oxAuthLogoutSessionRequired'] = str(oxAuthLogoutSessionRequired).encode().lower()
+        attrs['oxAuthTrustedClient'] = str(oxAuthTrustedClient).encode().lower()
+        attrs['oxAuthResponseType'] = str(oxAuthResponseType).encode()
+        attrs['oxAuthTokenEndpointAuthMethod'] = str(oxAuthTokenEndpointAuthMethod).encode()
+        attrs['oxAuthRequireAuthTime'] = str(oxAuthRequireAuthTime).encode().lower()
+        attrs['oxAccessTokenAsJwt'] = str(oxAccessTokenAsJwt).encode().lower()
+        attrs['oxPersistClientAuthorizations'] = str(oxPersistClientAuthorizations).encode().lower()
+        attrs['oxAuthGrantType'] = str(oxAuthGrantType).encode()
+        attrs['oxAttributes'] = str(oxAttributes).encode()
+        attrs['oxAuthAppType'] = str(oxAuthAppType).encode()
+        attrs['oxIncludeClaimsInIdToken'] = str(oxIncludeClaimsInIdToken).encode().lower()
+        attrs['oxRptAsJwt'] = str(oxRptAsJwt).encode().lower()
+        attrs['oxAuthClientSecret'] = str(oxAuthClientSecret).encode()
+        attrs['oxAuthSubjectType'] = str(oxAuthSubjectType).encode()
+        attrs['oxDisabled'] = str(oxDisabled).encode().lower()
+
+
+
+        static_attrs = {"objectClass": ["top".encode(), "oxAuthClient".encode()],
+        "oxAuthScope": [
+            "inum=F0C4,ou=scopes,o=gluu".encode(),
+            "inum=C4F5,ou=scopes,o=gluu".encode(),
+        ],
+        "inum": "w124asdgggAGs".encode()
+        }
+
+        attrs.update(static_attrs)
+        all_attrs = attrs
+
+        new_dn = "inum=%s,%s" % (static_attrs['inum'].decode(),self.dn)
+        # create modification list
+        ldif = modlist.addModlist(all_attrs)
+
+
+        self.connection.connect.add_s(new_dn, ldif)
+        created_op = self.get_op_by_display_name(attrs['displayName'].decode())
+        return created_op
+
+
+

--- a/ldaphelper/op.py
+++ b/ldaphelper/op.py
@@ -1,13 +1,16 @@
 import ldaphelper
 
+
 class Op:
     connection = None
-    dn = 'ou=clients,o=gluu'
+    dn = "ou=clients,o=gluu"
+
     def __init__(self, connection: ldaphelper.LdapConnector):
         self.connection = connection
 
-    def get_op_by_display_name(self,displayName: str):
+    def get_op_by_display_name(self, displayName: str):
         op_client = self.connection.connect.search_s(
-            self.dn,self.connection.searchScope,'displayName=%s' % displayName)
-        #import ipdb; ipdb.set_trace()
+            self.dn, self.connection.searchScope,
+            "displayName=%s" % displayName)
+        # import ipdb; ipdb.set_trace()
         return op_client[0]

--- a/ldaphelper/op.py
+++ b/ldaphelper/op.py
@@ -9,4 +9,5 @@ class Op:
     def get_op_by_display_name(self,displayName: str):
         op_client = self.connection.connect.search_s(
             self.dn,self.connection.searchScope,'displayName=%s' % displayName)
+        #import ipdb; ipdb.set_trace()
         return op_client[0]

--- a/setup.py
+++ b/setup.py
@@ -18,5 +18,5 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    python_requires='>=3.6',
+    python_requires=">=3.6",
 )

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,8 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setuptools.setup(
-    name="ldaphelper", # Replace with your own username
-    version="0.0.3",
+    name="ldaphelper",
+    version="0.0.4",
     author="Christian Eland",
     author_email="eland.christian@gmail.com",
     description="Wanna make ldap handling a little easier",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="ldaphelper",
-    version="0.0.4",
+    version="0.2.0",
     author="Christian Eland",
     author_email="eland.christian@gmail.com",
     description="Wanna make ldap handling a little easier",

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -1,34 +1,33 @@
 # mock data
 
-
 OP_STATIC_ATTRS = {
-        "objectClass": ["top", "oxAuthClient"],
-        "oxAuthScope": [
-            "inum=F0C4,ou=scopes,o=gluu",
-            "inum=C4F5,ou=scopes,o=gluu",
-        ],
-        "inum": "w124asdgggAGs"
-        }
-
+    "objectClass": ["top", "oxAuthClient"],
+    "oxAuthScope": [
+        "inum=F0C4,ou=scopes,o=gluu",
+        "inum=C4F5,ou=scopes,o=gluu",
+    ],
+    "inum": "w124asdgggAGs",
+}
 
 ADD_OP_TEST_ARGS = {
-        "oxAuthLogoutSessionRequired": False,
-        "oxAuthTrustedClient": False,
-        "oxAuthResponseType": "token",
-        "oxAuthTokenEndpointAuthMethod": "client_secret_basic",
-        "oxAuthRequireAuthTime": False,
-        "oxAccessTokenAsJwt": False,
-        "oxPersistClientAuthorizations": True,
-        "oxAuthGrantType": "client_credentials",
-        "oxAttributes": '{"tlsClientAuthSubjectDn":null,"runIntrospectionScriptBeforeAccessTokenAsJwtCreationAndIncludeClaims":false,"keepClientAuthorizationAfterExpiration":false}',
-        "oxAuthAppType": "web",
-        "oxDisabled": False,
-        "oxIncludeClaimsInIdToken": False,
-        "oxRptAsJwt": False,
-        "displayName": "test-client2",
-        "oxAuthClientSecret": "somecoolsecret",
-        "oxAuthSubjectType": "pairwise",
-    }
+    "oxAuthLogoutSessionRequired": False,
+    "oxAuthTrustedClient": False,
+    "oxAuthResponseType": "token",
+    "oxAuthTokenEndpointAuthMethod": "client_secret_basic",
+    "oxAuthRequireAuthTime": False,
+    "oxAccessTokenAsJwt": False,
+    "oxPersistClientAuthorizations": True,
+    "oxAuthGrantType": "client_credentials",
+    "oxAttributes":
+    '{"tlsClientAuthSubjectDn":null,"runIntrospectionScriptBeforeAccessTokenAsJwtCreationAndIncludeClaims":false,"keepClientAuthorizationAfterExpiration":false}',
+    "oxAuthAppType": "web",
+    "oxDisabled": False,
+    "oxIncludeClaimsInIdToken": False,
+    "oxRptAsJwt": False,
+    "displayName": "test-client2",
+    "oxAuthClientSecret": "somecoolsecret",
+    "oxAuthSubjectType": "pairwise",
+}
 
 MOCKED_SEARCH_S_VALID_RESPONSE = [(
     "inum=59376804-e84b-411a-9492-653d14e52c24,ou=clients,o=gluu",
@@ -63,4 +62,30 @@ MOCKED_SEARCH_S_VALID_RESPONSE = [(
     },
 )]
 
-OP_ADD_OP_EXPECTED_RETURN = expected_created_op = ('inum=w124asdgggAGs,ou=clients,o=gluu', {'objectClass': [b'top', b'oxAuthClient'], 'oxAuthLogoutSessionRequired': [b'false'], 'oxAuthTrustedClient': [b'false'], 'oxAuthScope': [b'inum=F0C4,ou=scopes,o=gluu', b'inum=C4F5,ou=scopes,o=gluu'], 'oxAuthResponseType': [b'token'], 'oxAuthTokenEndpointAuthMethod': [b'client_secret_basic'], 'oxAuthRequireAuthTime': [b'false'], 'oxAccessTokenAsJwt': [b'false'], 'oxPersistClientAuthorizations': [b'true'], 'oxAuthGrantType': [b'client_credentials'], 'inum': [b'w124asdgggAGs'], 'oxAttributes': [b'{"tlsClientAuthSubjectDn":null,"runIntrospectionScriptBeforeAccessTokenAsJwtCreationAndIncludeClaims":false,"keepClientAuthorizationAfterExpiration":false}'], 'oxAuthAppType': [b'web'], 'oxIncludeClaimsInIdToken': [b'false'], 'oxRptAsJwt': [b'false'], 'oxDisabled': [b'false'], 'displayName': [b'test-client2'], 'oxAuthClientSecret': [b'somecoolsecret'], 'oxAuthSubjectType': [b'pairwise']})
+OP_ADD_OP_EXPECTED_RETURN = expected_created_op = (
+    "inum=w124asdgggAGs,ou=clients,o=gluu",
+    {
+        "objectClass": [b"top", b"oxAuthClient"],
+        "oxAuthLogoutSessionRequired": [b"false"],
+        "oxAuthTrustedClient": [b"false"],
+        "oxAuthScope":
+        [b"inum=F0C4,ou=scopes,o=gluu", b"inum=C4F5,ou=scopes,o=gluu"],
+        "oxAuthResponseType": [b"token"],
+        "oxAuthTokenEndpointAuthMethod": [b"client_secret_basic"],
+        "oxAuthRequireAuthTime": [b"false"],
+        "oxAccessTokenAsJwt": [b"false"],
+        "oxPersistClientAuthorizations": [b"true"],
+        "oxAuthGrantType": [b"client_credentials"],
+        "inum": [b"w124asdgggAGs"],
+        "oxAttributes": [
+            b'{"tlsClientAuthSubjectDn":null,"runIntrospectionScriptBeforeAccessTokenAsJwtCreationAndIncludeClaims":false,"keepClientAuthorizationAfterExpiration":false}'
+        ],
+        "oxAuthAppType": [b"web"],
+        "oxIncludeClaimsInIdToken": [b"false"],
+        "oxRptAsJwt": [b"false"],
+        "oxDisabled": [b"false"],
+        "displayName": [b"test-client2"],
+        "oxAuthClientSecret": [b"somecoolsecret"],
+        "oxAuthSubjectType": [b"pairwise"],
+    },
+)

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -1,0 +1,20 @@
+
+# mock data
+
+MOCKED_SEARCH_S_VALID_RESPONSE = [
+    ('inum=59376804-e84b-411a-9492-653d14e52c24,ou=clients,o=gluu',
+    {'objectClass': [b'top', b'oxAuthClient'],
+    'oxAuthLogoutSessionRequired': [b'false'],
+    'oxAuthScope': [b'inum=F0C4,ou=scopes,o=gluu', b'inum=C4F5,ou=scopes,o=gluu'],
+    'oxAuthTrustedClient': [b'false'], 'oxAuthResponseType': [b'token'],
+    'oxAuthTokenEndpointAuthMethod': [b'client_secret_basic'],
+    'oxAuthRequireAuthTime': [b'false'], 'oxAccessTokenAsJwt': [b'false'],
+    'oxPersistClientAuthorizations': [b'true'], 'oxAuthGrantType': [b'client_credentials'],
+    'inum': [b'59376804-e84b-411a-9492-653d14e52c24'],
+    'oxAttributes': [b'{"tlsClientAuthSubjectDn":null,"runIntrospectionScriptBeforeAccessTokenAsJwtCreationAndIncludeClaims":false,"keepClientAuthorizationAfterExpiration":false}'],
+    'oxAuthAppType': [b'web'], 'oxLastLogonTime': [b'20200714072830.011Z'],
+    'oxAuthClientSecretExpiresAt': [b'21200623000000.000Z'], 'oxDisabled': [b'false'],
+    'oxIncludeClaimsInIdToken': [b'false'], 'oxRptAsJwt': [b'false'],
+    'displayName': [b'test-client'], 'oxAuthClientSecret': [b'gWxnjnUdCm8Rpc0WPmm9lQ=='],
+    'oxAuthSubjectType': [b'pairwise'], 'oxLastAccessTime': [b'20200714072830.011Z']})
+    ]

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -1,20 +1,34 @@
-
 # mock data
 
-MOCKED_SEARCH_S_VALID_RESPONSE = [
-    ('inum=59376804-e84b-411a-9492-653d14e52c24,ou=clients,o=gluu',
-    {'objectClass': [b'top', b'oxAuthClient'],
-    'oxAuthLogoutSessionRequired': [b'false'],
-    'oxAuthScope': [b'inum=F0C4,ou=scopes,o=gluu', b'inum=C4F5,ou=scopes,o=gluu'],
-    'oxAuthTrustedClient': [b'false'], 'oxAuthResponseType': [b'token'],
-    'oxAuthTokenEndpointAuthMethod': [b'client_secret_basic'],
-    'oxAuthRequireAuthTime': [b'false'], 'oxAccessTokenAsJwt': [b'false'],
-    'oxPersistClientAuthorizations': [b'true'], 'oxAuthGrantType': [b'client_credentials'],
-    'inum': [b'59376804-e84b-411a-9492-653d14e52c24'],
-    'oxAttributes': [b'{"tlsClientAuthSubjectDn":null,"runIntrospectionScriptBeforeAccessTokenAsJwtCreationAndIncludeClaims":false,"keepClientAuthorizationAfterExpiration":false}'],
-    'oxAuthAppType': [b'web'], 'oxLastLogonTime': [b'20200714072830.011Z'],
-    'oxAuthClientSecretExpiresAt': [b'21200623000000.000Z'], 'oxDisabled': [b'false'],
-    'oxIncludeClaimsInIdToken': [b'false'], 'oxRptAsJwt': [b'false'],
-    'displayName': [b'test-client'], 'oxAuthClientSecret': [b'gWxnjnUdCm8Rpc0WPmm9lQ=='],
-    'oxAuthSubjectType': [b'pairwise'], 'oxLastAccessTime': [b'20200714072830.011Z']})
-    ]
+MOCKED_SEARCH_S_VALID_RESPONSE = [(
+    "inum=59376804-e84b-411a-9492-653d14e52c24,ou=clients,o=gluu",
+    {
+        "objectClass": [b"top", b"oxAuthClient"],
+        "oxAuthLogoutSessionRequired": [b"false"],
+        "oxAuthScope": [
+            b"inum=F0C4,ou=scopes,o=gluu",
+            b"inum=C4F5,ou=scopes,o=gluu",
+        ],
+        "oxAuthTrustedClient": [b"false"],
+        "oxAuthResponseType": [b"token"],
+        "oxAuthTokenEndpointAuthMethod": [b"client_secret_basic"],
+        "oxAuthRequireAuthTime": [b"false"],
+        "oxAccessTokenAsJwt": [b"false"],
+        "oxPersistClientAuthorizations": [b"true"],
+        "oxAuthGrantType": [b"client_credentials"],
+        "inum": [b"59376804-e84b-411a-9492-653d14e52c24"],
+        "oxAttributes": [
+            b'{"tlsClientAuthSubjectDn":null,"runIntrospectionScriptBeforeAccessTokenAsJwtCreationAndIncludeClaims":false,"keepClientAuthorizationAfterExpiration":false}'
+        ],
+        "oxAuthAppType": [b"web"],
+        "oxLastLogonTime": [b"20200714072830.011Z"],
+        "oxAuthClientSecretExpiresAt": [b"21200623000000.000Z"],
+        "oxDisabled": [b"false"],
+        "oxIncludeClaimsInIdToken": [b"false"],
+        "oxRptAsJwt": [b"false"],
+        "displayName": [b"test-client"],
+        "oxAuthClientSecret": [b"gWxnjnUdCm8Rpc0WPmm9lQ=="],
+        "oxAuthSubjectType": [b"pairwise"],
+        "oxLastAccessTime": [b"20200714072830.011Z"],
+    },
+)]

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -1,5 +1,35 @@
 # mock data
 
+
+OP_STATIC_ATTRS = {
+        "objectClass": ["top", "oxAuthClient"],
+        "oxAuthScope": [
+            "inum=F0C4,ou=scopes,o=gluu",
+            "inum=C4F5,ou=scopes,o=gluu",
+        ],
+        "inum": "w124asdgggAGs"
+        }
+
+
+ADD_OP_TEST_ARGS = {
+        "oxAuthLogoutSessionRequired": False,
+        "oxAuthTrustedClient": False,
+        "oxAuthResponseType": "token",
+        "oxAuthTokenEndpointAuthMethod": "client_secret_basic",
+        "oxAuthRequireAuthTime": False,
+        "oxAccessTokenAsJwt": False,
+        "oxPersistClientAuthorizations": True,
+        "oxAuthGrantType": "client_credentials",
+        "oxAttributes": '{"tlsClientAuthSubjectDn":null,"runIntrospectionScriptBeforeAccessTokenAsJwtCreationAndIncludeClaims":false,"keepClientAuthorizationAfterExpiration":false}',
+        "oxAuthAppType": "web",
+        "oxDisabled": False,
+        "oxIncludeClaimsInIdToken": False,
+        "oxRptAsJwt": False,
+        "displayName": "test-client2",
+        "oxAuthClientSecret": "somecoolsecret",
+        "oxAuthSubjectType": "pairwise",
+    }
+
 MOCKED_SEARCH_S_VALID_RESPONSE = [(
     "inum=59376804-e84b-411a-9492-653d14e52c24,ou=clients,o=gluu",
     {
@@ -32,3 +62,5 @@ MOCKED_SEARCH_S_VALID_RESPONSE = [(
         "oxLastAccessTime": [b"20200714072830.011Z"],
     },
 )]
+
+OP_ADD_OP_EXPECTED_RETURN = expected_created_op = ('inum=w124asdgggAGs,ou=clients,o=gluu', {'objectClass': [b'top', b'oxAuthClient'], 'oxAuthLogoutSessionRequired': [b'false'], 'oxAuthTrustedClient': [b'false'], 'oxAuthScope': [b'inum=F0C4,ou=scopes,o=gluu', b'inum=C4F5,ou=scopes,o=gluu'], 'oxAuthResponseType': [b'token'], 'oxAuthTokenEndpointAuthMethod': [b'client_secret_basic'], 'oxAuthRequireAuthTime': [b'false'], 'oxAccessTokenAsJwt': [b'false'], 'oxPersistClientAuthorizations': [b'true'], 'oxAuthGrantType': [b'client_credentials'], 'inum': [b'w124asdgggAGs'], 'oxAttributes': [b'{"tlsClientAuthSubjectDn":null,"runIntrospectionScriptBeforeAccessTokenAsJwtCreationAndIncludeClaims":false,"keepClientAuthorizationAfterExpiration":false}'], 'oxAuthAppType': [b'web'], 'oxIncludeClaimsInIdToken': [b'false'], 'oxRptAsJwt': [b'false'], 'oxDisabled': [b'false'], 'displayName': [b'test-client2'], 'oxAuthClientSecret': [b'somecoolsecret'], 'oxAuthSubjectType': [b'pairwise']})

--- a/tests/test_ldapconnector.py
+++ b/tests/test_ldapconnector.py
@@ -18,6 +18,7 @@ class TestLdapConnector(TestCase):
             ModuleType,
             'ldap is not a module'
         )
+
     def test_ldap_exists_as_module(self):
         self.assertIn(
             'ldap',

--- a/tests/test_op.py
+++ b/tests/test_op.py
@@ -15,7 +15,6 @@ def get_Op_instance():
     connection.__setattr__("connect", ldap.ldapobject.SimpleLDAPObject)
     op_instance = op.Op(connection)
 
-
     return op_instance
 
 
@@ -24,22 +23,22 @@ class TestOp(TestCase):
         # mocks
         self.op_instance = get_Op_instance()
         self.search_s = patch.object(
-                    self.op_instance.connection.connect,
-                    "search_s",
-                    return_value=helper.MOCKED_SEARCH_S_VALID_RESPONSE)
+            self.op_instance.connection.connect,
+            "search_s",
+            return_value=helper.MOCKED_SEARCH_S_VALID_RESPONSE,
+        )
         self.add_s = patch.object(
-                    self.op_instance.connection.connect,
-                    'add_s',
-                    return_value = helper.OP_ADD_OP_EXPECTED_RETURN)
+            self.op_instance.connection.connect,
+            "add_s",
+            return_value=helper.OP_ADD_OP_EXPECTED_RETURN,
+        )
 
         self.search_s.start()
         self.add_s.start()
 
-
     def tearDown(self):
         self.search_s.stop()
         self.add_s.stop()
-
 
     def test_should_return_if_op_exists(self):
         self.assertTrue(hasattr(ldaphelper, "op"),
@@ -48,14 +47,11 @@ class TestOp(TestCase):
     def test_if_op_is_module(self):
         self.assertIsInstance(op, ModuleType, "op is not a module")
 
-
     def test_if_Op_exists(self):
         self.assertTrue(hasattr(op, "Op"), "Op does not exist in op")
 
-
     def test_if_Op_is_class(self):
         self.assertTrue(type(op.Op) is type, "Op is not type (not a Class)")
-
 
     def test_if_Op_receives_LdapConnector(self):
         """[Check if Op receives class LdapConnector as arg]
@@ -70,34 +66,28 @@ class TestOp(TestCase):
             "Op does not receive LdapConnector class as arg",
         )
 
-
     def test_if_Op_has_attr_connection(self):
         self.assertTrue(hasattr(op.Op, "connection"),
                         "Op has no attribute named connection")
 
-
     def test_if_connection_is_none(self):
         self.assertIsNone(op.Op.connection, "connection is not none")
-
 
     def test_if_init_Op_connection_sets_LdapConnector_instance(self):
         self.assertIsInstance(
             self.op_instance.connection,
             ldaphelper.ldapconnector.LdapConnector,
-            "connection is not an instance of LdapConnector after __init__"
+            "connection is not an instance of LdapConnector after __init__",
         )
-
 
     def test_if_get_op_by_display_name_exists_in_Op(self):
         self.assertTrue(hasattr(op.Op, "get_op_by_display_name"))
 
-
     def test_if_get_op_by_display_name_is_callable(self):
         self.assertTrue(
             callable(op.Op.get_op_by_display_name),
-            "get_op_by_display_name is not callable"
+            "get_op_by_display_name is not callable",
         )
-
 
     def test_get_op_by_display_name_should_return_a_tuple(self):
         self.assertIsInstance(
@@ -109,17 +99,16 @@ class TestOp(TestCase):
     def test_if_Op_has_dn(self):
         self.assertTrue(hasattr(op.Op, "dn"), "Op does not have dn attribute")
 
-
     def test_if_dn_is_string(self):
         self.assertTrue(type(op.Op.dn) is str, "dn is not a string")
-
 
     def test_if_get_op_by_display_name_one_return_dict(self):
         """ get_op_by_display_name[1] """
         with patch.object(
                 self.op_instance.connection.connect,
                 "search_s",
-                return_value=helper.MOCKED_SEARCH_S_VALID_RESPONSE):
+                return_value=helper.MOCKED_SEARCH_S_VALID_RESPONSE,
+        ):
             op_client = self.op_instance.get_op_by_display_name("test-client")
             self.assertTrue(
                 type(op_client[1]) is dict,
@@ -156,15 +145,11 @@ class TestOp(TestCase):
             "search response[1] tuple does not have expected keys",
         )
 
-
     def test_if_add_op_exists(self):
-        self.assertTrue(hasattr(op.Op, 'add_op'))
-
+        self.assertTrue(hasattr(op.Op, "add_op"))
 
     def test_if_add_op_is_callable(self):
-        self.assertTrue(callable(op.Op.add_op),
-            'add_op is not callable')
-
+        self.assertTrue(callable(op.Op.add_op), "add_op is not callable")
 
     def test_if_add_op_receives_needed_args(self):
         needed_args = [
@@ -185,15 +170,15 @@ class TestOp(TestCase):
             "oxAuthClientSecret",
             "oxAuthSubjectType",
             "oxDisabled",
-            ]
+        ]
         method_args = inspect.getfullargspec(op.Op.add_op).args
-        self.assertListEqual(needed_args,method_args)
-
+        self.assertListEqual(needed_args, method_args)
 
     def test_if_add_op_returns_tuple(self):
-        self.assertTrue( type(self.op_instance.add_op(**helper.ADD_OP_TEST_ARGS)) is tuple,
-            'add_op does not return a tuple')
-
+        self.assertTrue(
+            type(self.op_instance.add_op(**helper.ADD_OP_TEST_ARGS)) is tuple,
+            "add_op does not return a tuple",
+        )
 
     def test_if_add_op_returns_valid_op_attrs(self):
         valid_keys = []
@@ -206,28 +191,55 @@ class TestOp(TestCase):
             "add_op returning attrs do not have expected keys",
         )
 
-
     def test_if_add_op_calls_add_modlist_with_args(self):
 
-        with patch.object(
-                ldaphelper.ldapconnector.modlist,
-                'addModlist') as addModlist:
+        with patch.object(ldaphelper.ldapconnector.modlist,
+                          "addModlist") as addModlist:
 
             self.op_instance.add_op(**helper.ADD_OP_TEST_ARGS)
-            all_attrs = {'displayName': b'test-client2', 'oxAuthLogoutSessionRequired': b'false',
-            'oxAuthTrustedClient': b'false', 'oxAuthResponseType': b'token',
-            'oxAuthTokenEndpointAuthMethod': b'client_secret_basic', 'oxAuthRequireAuthTime': b'false',
-            'oxAccessTokenAsJwt': b'false', 'oxPersistClientAuthorizations': b'true',
-            'oxAuthGrantType': b'client_credentials',
-            'oxAttributes': b'{"tlsClientAuthSubjectDn":null,"runIntrospectionScriptBeforeAccessTokenAsJwtCreationAndIncludeClaims":false,"keepClientAuthorizationAfterExpiration":false}',
-            'oxAuthAppType': b'web', 'oxIncludeClaimsInIdToken': b'false', 'oxRptAsJwt': b'false',
-            'oxAuthClientSecret': b'somecoolsecret', 'oxAuthSubjectType': b'pairwise',
-            'oxDisabled': b'false',
-            'objectClass': [b'top', b'oxAuthClient'],
-            'oxAuthScope': [b'inum=F0C4,ou=scopes,o=gluu', b'inum=C4F5,ou=scopes,o=gluu'], 'inum': b'w124asdgggAGs'}
+            all_attrs = {
+                "displayName":
+                b"test-client2",
+                "oxAuthLogoutSessionRequired":
+                b"false",
+                "oxAuthTrustedClient":
+                b"false",
+                "oxAuthResponseType":
+                b"token",
+                "oxAuthTokenEndpointAuthMethod":
+                b"client_secret_basic",
+                "oxAuthRequireAuthTime":
+                b"false",
+                "oxAccessTokenAsJwt":
+                b"false",
+                "oxPersistClientAuthorizations":
+                b"true",
+                "oxAuthGrantType":
+                b"client_credentials",
+                "oxAttributes":
+                b'{"tlsClientAuthSubjectDn":null,"runIntrospectionScriptBeforeAccessTokenAsJwtCreationAndIncludeClaims":false,"keepClientAuthorizationAfterExpiration":false}',
+                "oxAuthAppType":
+                b"web",
+                "oxIncludeClaimsInIdToken":
+                b"false",
+                "oxRptAsJwt":
+                b"false",
+                "oxAuthClientSecret":
+                b"somecoolsecret",
+                "oxAuthSubjectType":
+                b"pairwise",
+                "oxDisabled":
+                b"false",
+                "objectClass": [b"top", b"oxAuthClient"],
+                "oxAuthScope": [
+                    b"inum=F0C4,ou=scopes,o=gluu",
+                    b"inum=C4F5,ou=scopes,o=gluu",
+                ],
+                "inum":
+                b"w124asdgggAGs",
+            }
 
             addModlist.assert_called_once_with(all_attrs)
-
 
     def test_if_add_op_calls_ldap_add_s(self):
 
@@ -235,30 +247,77 @@ class TestOp(TestCase):
 
             self.op_instance.add_op(**helper.ADD_OP_TEST_ARGS)
 
-            add_s.assert_called_once_with('inum=w124asdgggAGs,ou=clients,o=gluu',
-                [('displayName', b'test-client2'), ('oxAuthLogoutSessionRequired', b'false'),
-                ('oxAuthTrustedClient', b'false'), ('oxAuthResponseType', b'token'),
-                ('oxAuthTokenEndpointAuthMethod', b'client_secret_basic'), ('oxAuthRequireAuthTime', b'false'),
-                ('oxAccessTokenAsJwt', b'false'), ('oxPersistClientAuthorizations', b'true'),
-                ('oxAuthGrantType', b'client_credentials'),
-                ('oxAttributes', b'{"tlsClientAuthSubjectDn":null,"runIntrospectionScriptBeforeAccessTokenAsJwtCreationAndIncludeClaims":false,"keepClientAuthorizationAfterExpiration":false}'),
-                ('oxAuthAppType', b'web'),
-                ('oxIncludeClaimsInIdToken', b'false'),
-                ('oxRptAsJwt', b'false'),
-                ('oxAuthClientSecret', b'somecoolsecret'),
-                ('oxAuthSubjectType', b'pairwise'),
-                ('oxDisabled', b'false'), ('objectClass', [b'top', b'oxAuthClient']),
-                ('oxAuthScope', [b'inum=F0C4,ou=scopes,o=gluu', b'inum=C4F5,ou=scopes,o=gluu']), ('inum', b'w124asdgggAGs')])
+            add_s.assert_called_once_with(
+                "inum=w124asdgggAGs,ou=clients,o=gluu",
+                [
+                    ("displayName", b"test-client2"),
+                    ("oxAuthLogoutSessionRequired", b"false"),
+                    ("oxAuthTrustedClient", b"false"),
+                    ("oxAuthResponseType", b"token"),
+                    ("oxAuthTokenEndpointAuthMethod", b"client_secret_basic"),
+                    ("oxAuthRequireAuthTime", b"false"),
+                    ("oxAccessTokenAsJwt", b"false"),
+                    ("oxPersistClientAuthorizations", b"true"),
+                    ("oxAuthGrantType", b"client_credentials"),
+                    (
+                        "oxAttributes",
+                        b'{"tlsClientAuthSubjectDn":null,"runIntrospectionScriptBeforeAccessTokenAsJwtCreationAndIncludeClaims":false,"keepClientAuthorizationAfterExpiration":false}',
+                    ),
+                    ("oxAuthAppType", b"web"),
+                    ("oxIncludeClaimsInIdToken", b"false"),
+                    ("oxRptAsJwt", b"false"),
+                    ("oxAuthClientSecret", b"somecoolsecret"),
+                    ("oxAuthSubjectType", b"pairwise"),
+                    ("oxDisabled", b"false"),
+                    ("objectClass", [b"top", b"oxAuthClient"]),
+                    (
+                        "oxAuthScope",
+                        [
+                            b"inum=F0C4,ou=scopes,o=gluu",
+                            b"inum=C4F5,ou=scopes,o=gluu"
+                        ],
+                    ),
+                    ("inum", b"w124asdgggAGs"),
+                ],
+            )
         # restarting
         self.add_s.start()
 
-
     def test_add_op_should_return_created_op(self):
-        expected_created_op = ('inum=59376804-e84b-411a-9492-653d14e52c24,ou=clients,o=gluu', {'objectClass': [b'top', b'oxAuthClient'], 'oxAuthLogoutSessionRequired': [b'false'], 'oxAuthScope': [b'inum=F0C4,ou=scopes,o=gluu', b'inum=C4F5,ou=scopes,o=gluu'], 'oxAuthTrustedClient': [b'false'], 'oxAuthResponseType': [b'token'], 'oxAuthTokenEndpointAuthMethod': [b'client_secret_basic'], 'oxAuthRequireAuthTime': [b'false'], 'oxAccessTokenAsJwt': [b'false'], 'oxPersistClientAuthorizations': [b'true'], 'oxAuthGrantType': [b'client_credentials'], 'inum': [b'59376804-e84b-411a-9492-653d14e52c24'], 'oxAttributes': [b'{"tlsClientAuthSubjectDn":null,"runIntrospectionScriptBeforeAccessTokenAsJwtCreationAndIncludeClaims":false,"keepClientAuthorizationAfterExpiration":false}'], 'oxAuthAppType': [b'web'], 'oxLastLogonTime': [b'20200714072830.011Z'], 'oxAuthClientSecretExpiresAt': [b'21200623000000.000Z'], 'oxDisabled': [b'false'], 'oxIncludeClaimsInIdToken': [b'false'], 'oxRptAsJwt': [b'false'], 'displayName': [b'test-client'], 'oxAuthClientSecret': [b'gWxnjnUdCm8Rpc0WPmm9lQ=='], 'oxAuthSubjectType': [b'pairwise'], 'oxLastAccessTime': [b'20200714072830.011Z']})
+        expected_created_op = (
+            "inum=59376804-e84b-411a-9492-653d14e52c24,ou=clients,o=gluu",
+            {
+                "objectClass": [b"top", b"oxAuthClient"],
+                "oxAuthLogoutSessionRequired": [b"false"],
+                "oxAuthScope": [
+                    b"inum=F0C4,ou=scopes,o=gluu",
+                    b"inum=C4F5,ou=scopes,o=gluu",
+                ],
+                "oxAuthTrustedClient": [b"false"],
+                "oxAuthResponseType": [b"token"],
+                "oxAuthTokenEndpointAuthMethod": [b"client_secret_basic"],
+                "oxAuthRequireAuthTime": [b"false"],
+                "oxAccessTokenAsJwt": [b"false"],
+                "oxPersistClientAuthorizations": [b"true"],
+                "oxAuthGrantType": [b"client_credentials"],
+                "inum": [b"59376804-e84b-411a-9492-653d14e52c24"],
+                "oxAttributes": [
+                    b'{"tlsClientAuthSubjectDn":null,"runIntrospectionScriptBeforeAccessTokenAsJwtCreationAndIncludeClaims":false,"keepClientAuthorizationAfterExpiration":false}'
+                ],
+                "oxAuthAppType": [b"web"],
+                "oxLastLogonTime": [b"20200714072830.011Z"],
+                "oxAuthClientSecretExpiresAt": [b"21200623000000.000Z"],
+                "oxDisabled": [b"false"],
+                "oxIncludeClaimsInIdToken": [b"false"],
+                "oxRptAsJwt": [b"false"],
+                "displayName": [b"test-client"],
+                "oxAuthClientSecret": [b"gWxnjnUdCm8Rpc0WPmm9lQ=="],
+                "oxAuthSubjectType": [b"pairwise"],
+                "oxLastAccessTime": [b"20200714072830.011Z"],
+            },
+        )
         self.assertEqual(
             self.op_instance.add_op(**helper.ADD_OP_TEST_ARGS),
             expected_created_op,
-            'add_op() is not returning created_op'
+            "add_op() is not returning created_op",
         )
-
-

--- a/tests/test_op.py
+++ b/tests/test_op.py
@@ -71,7 +71,7 @@ class TestOp(TestCase):
 
     def test_if_get_op_by_display_name_is_callable(self):
         self.assertTrue(
-            hasattr(op.Op.get_op_by_display_name, "__call__"),
+            callable(op.Op.get_op_by_display_name),
             "get_op_by_display_name is not callable",
         )
 

--- a/tests/test_op.py
+++ b/tests/test_op.py
@@ -5,6 +5,7 @@ from ldaphelper import op
 from types import ModuleType
 import inspect
 import ldap
+import helper
 
 ldap.initialize
 
@@ -92,9 +93,7 @@ class TestOp(TestCase):
 
         op_instance = get_Op_instance()
         with patch.object(op_instance.connection.connect, 'search_s',
-            return_value = (('aaa','ddd'),)) as search_s:
-            """ @TODO: change return_value to mocked real response """
-
+            return_value = (helper.MOCKED_SEARCH_S_VALID_RESPONSE)) as search_s:
             self.assertIsInstance(
                 op.Op.get_op_by_display_name(op_instance,'test-client'),
                 tuple,
@@ -111,23 +110,28 @@ class TestOp(TestCase):
 
     def test_if_get_op_by_display_name_one_return_dict(self):
         """ get_op_by_display_name[1] """
-        connection = ldaphelper.LdapConnector('cn=directory manager','Test123$')
-        oprovider = op.Op(connection)
-        tp = oprovider.get_op_by_display_name('test-client')
-        self.assertTrue(type(tp[1]) == dict,'get_op_by_display_name[1] is not a dict')
+        # mocked
+        op_instance = get_Op_instance()
+        with patch.object(op_instance.connection.connect, 'search_s',
+            return_value = (helper.MOCKED_SEARCH_S_VALID_RESPONSE)) as search_s:
+            op_client = op_instance.get_op_by_display_name('test-client')
+            self.assertTrue(type(op_client[1]) == dict,'get_op_by_display_name[1] is not a dict')
 
     def test_if_get_op_by_display_name_returns_valid_tuple(self):
-        connection = ldaphelper.LdapConnector('cn=directory manager','Test123$')
-        oprovider = op.Op(connection)
-        tp = oprovider.get_op_by_display_name('test-client')
+        op_instance = get_Op_instance()
+        with patch.object(op_instance.connection.connect, 'search_s',
+            return_value = (helper.MOCKED_SEARCH_S_VALID_RESPONSE)) as search_s:
 
-        some_keys = ['objectClass', 'oxAuthScope', 'oxAuthTrustedClient', 'oxAuthResponseType',
-            'oxAuthTokenEndpointAuthMethod', 'oxAuthRequireAuthTime', 'oxAccessTokenAsJwt',
-            'oxPersistClientAuthorizations', 'oxAuthGrantType', 'inum', 'oxAttributes', 'oxAuthAppType',
-            'oxLastLogonTime', 'oxDisabled', 'oxIncludeClaimsInIdToken', 'oxRptAsJwt', 'displayName',
-            'oxAuthClientSecret', 'oxAuthSubjectType']
-        #import ipdb; ipdb.set_trace()
-        self.assertTrue(set(some_keys).issubset(tp[1]),'search response tuple does not have expected keys')
+            tp = op_instance.get_op_by_display_name('test-client')
+
+            some_keys = ['objectClass', 'oxAuthScope', 'oxAuthTrustedClient', 'oxAuthResponseType',
+                'oxAuthTokenEndpointAuthMethod', 'oxAuthRequireAuthTime', 'oxAccessTokenAsJwt',
+                'oxPersistClientAuthorizations', 'oxAuthGrantType', 'inum', 'oxAttributes', 'oxAuthAppType',
+                'oxLastLogonTime', 'oxDisabled', 'oxIncludeClaimsInIdToken', 'oxRptAsJwt', 'displayName',
+                'oxAuthClientSecret', 'oxAuthSubjectType']
+
+            #import ipdb; ipdb.set_trace()
+            self.assertTrue(set(some_keys).issubset(tp[1]),'search response[1] tuple does not have expected keys')
 
 
 

--- a/tests/test_op.py
+++ b/tests/test_op.py
@@ -93,7 +93,7 @@ class TestOp(TestCase):
 
         op_instance = get_Op_instance()
         with patch.object(op_instance.connection.connect, 'search_s',
-            return_value = (helper.MOCKED_SEARCH_S_VALID_RESPONSE)) as search_s:
+            return_value = (helper.MOCKED_SEARCH_S_VALID_RESPONSE)):
             self.assertIsInstance(
                 op.Op.get_op_by_display_name(op_instance,'test-client'),
                 tuple,
@@ -113,14 +113,14 @@ class TestOp(TestCase):
         # mocked
         op_instance = get_Op_instance()
         with patch.object(op_instance.connection.connect, 'search_s',
-            return_value = (helper.MOCKED_SEARCH_S_VALID_RESPONSE)) as search_s:
+            return_value = (helper.MOCKED_SEARCH_S_VALID_RESPONSE)):
             op_client = op_instance.get_op_by_display_name('test-client')
             self.assertTrue(type(op_client[1]) == dict,'get_op_by_display_name[1] is not a dict')
 
     def test_if_get_op_by_display_name_returns_valid_tuple(self):
         op_instance = get_Op_instance()
         with patch.object(op_instance.connection.connect, 'search_s',
-            return_value = (helper.MOCKED_SEARCH_S_VALID_RESPONSE)) as search_s:
+            return_value = (helper.MOCKED_SEARCH_S_VALID_RESPONSE)):
 
             tp = op_instance.get_op_by_display_name('test-client')
 

--- a/tests/test_op.py
+++ b/tests/test_op.py
@@ -14,10 +14,33 @@ def get_Op_instance():
     connection = MagicMock(ldaphelper.ldapconnector.LdapConnector)
     connection.__setattr__("connect", ldap.ldapobject.SimpleLDAPObject)
     op_instance = op.Op(connection)
+
+
     return op_instance
 
 
 class TestOp(TestCase):
+    def setUp(self):
+        # mocks
+        self.op_instance = get_Op_instance()
+        self.search_s = patch.object(
+                    self.op_instance.connection.connect,
+                    "search_s",
+                    return_value=helper.MOCKED_SEARCH_S_VALID_RESPONSE)
+        self.add_s = patch.object(
+                    self.op_instance.connection.connect,
+                    'add_s',
+                    return_value = helper.OP_ADD_OP_EXPECTED_RETURN)
+
+        self.search_s.start()
+        self.add_s.start()
+
+
+    def tearDown(self):
+        self.search_s.stop()
+        self.add_s.stop()
+
+
     def test_should_return_if_op_exists(self):
         self.assertTrue(hasattr(ldaphelper, "op"),
                         "ldaphelper does not have op attribute")
@@ -25,11 +48,14 @@ class TestOp(TestCase):
     def test_if_op_is_module(self):
         self.assertIsInstance(op, ModuleType, "op is not a module")
 
+
     def test_if_Op_exists(self):
         self.assertTrue(hasattr(op, "Op"), "Op does not exist in op")
 
+
     def test_if_Op_is_class(self):
         self.assertTrue(type(op.Op) is type, "Op is not type (not a Class)")
+
 
     def test_if_Op_receives_LdapConnector(self):
         """[Check if Op receives class LdapConnector as arg]
@@ -44,100 +70,195 @@ class TestOp(TestCase):
             "Op does not receive LdapConnector class as arg",
         )
 
+
     def test_if_Op_has_attr_connection(self):
         self.assertTrue(hasattr(op.Op, "connection"),
                         "Op has no attribute named connection")
 
+
     def test_if_connection_is_none(self):
         self.assertIsNone(op.Op.connection, "connection is not none")
 
-    def test_if_init_Op_connection_sets_LdapConnector_instance(self):
-        # import ipdb; ipdb.set_trace()
-        op_instance = get_Op_instance()
 
+    def test_if_init_Op_connection_sets_LdapConnector_instance(self):
         self.assertIsInstance(
-            op_instance.connection,
+            self.op_instance.connection,
             ldaphelper.ldapconnector.LdapConnector,
-            "connection is not an instance of LdapConnector after __init__",
+            "connection is not an instance of LdapConnector after __init__"
         )
+
 
     def test_if_get_op_by_display_name_exists_in_Op(self):
         self.assertTrue(hasattr(op.Op, "get_op_by_display_name"))
 
+
     def test_if_get_op_by_display_name_is_callable(self):
         self.assertTrue(
             callable(op.Op.get_op_by_display_name),
-            "get_op_by_display_name is not callable",
+            "get_op_by_display_name is not callable"
         )
 
-    # @patch.object(ldaphelper.LdapConnector.connect, 'search_s')
+
     def test_get_op_by_display_name_should_return_a_tuple(self):
-
-        op_instance = get_Op_instance()
-        with patch.object(
-                op_instance.connection.connect,
-                "search_s",
-                return_value=helper.MOCKED_SEARCH_S_VALID_RESPONSE):
-
-            self.assertIsInstance(
-                op.Op.get_op_by_display_name(op_instance, "test-client"),
-                tuple,
-                "get_op_by_display_name() does not return a list",
-            )
+        self.assertIsInstance(
+            self.op_instance.get_op_by_display_name("test-client"),
+            tuple,
+            "get_op_by_display_name() does not return a list",
+        )
 
     def test_if_Op_has_dn(self):
         self.assertTrue(hasattr(op.Op, "dn"), "Op does not have dn attribute")
 
+
     def test_if_dn_is_string(self):
         self.assertTrue(type(op.Op.dn) is str, "dn is not a string")
 
+
     def test_if_get_op_by_display_name_one_return_dict(self):
         """ get_op_by_display_name[1] """
-        # mocked
-        op_instance = get_Op_instance()
         with patch.object(
-                op_instance.connection.connect,
+                self.op_instance.connection.connect,
                 "search_s",
                 return_value=helper.MOCKED_SEARCH_S_VALID_RESPONSE):
-            op_client = op_instance.get_op_by_display_name("test-client")
+            op_client = self.op_instance.get_op_by_display_name("test-client")
             self.assertTrue(
                 type(op_client[1]) is dict,
                 "get_op_by_display_name[1] is not a dict")
 
     def test_if_get_op_by_display_name_returns_valid_tuple(self):
-        op_instance = get_Op_instance()
-        with patch.object(
-                op_instance.connection.connect,
-                "search_s",
-                return_value=helper.MOCKED_SEARCH_S_VALID_RESPONSE):
+
+        tp = self.op_instance.get_op_by_display_name("test-client")
+
+        some_keys = [
+            "objectClass",
+            "oxAuthScope",
+            "oxAuthTrustedClient",
+            "oxAuthResponseType",
+            "oxAuthTokenEndpointAuthMethod",
+            "oxAuthRequireAuthTime",
+            "oxAccessTokenAsJwt",
+            "oxPersistClientAuthorizations",
+            "oxAuthGrantType",
+            "inum",
+            "oxAttributes",
+            "oxAuthAppType",
+            "oxLastLogonTime",
+            "oxDisabled",
+            "oxIncludeClaimsInIdToken",
+            "oxRptAsJwt",
+            "displayName",
+            "oxAuthClientSecret",
+            "oxAuthSubjectType",
+        ]
+
+        self.assertTrue(
+            set(some_keys).issubset(tp[1]),
+            "search response[1] tuple does not have expected keys",
+        )
 
 
-            tp = op_instance.get_op_by_display_name("test-client")
+    def test_if_add_op_exists(self):
+        self.assertTrue(hasattr(op.Op, 'add_op'))
 
-            some_keys = [
-                "objectClass",
-                "oxAuthScope",
-                "oxAuthTrustedClient",
-                "oxAuthResponseType",
-                "oxAuthTokenEndpointAuthMethod",
-                "oxAuthRequireAuthTime",
-                "oxAccessTokenAsJwt",
-                "oxPersistClientAuthorizations",
-                "oxAuthGrantType",
-                "inum",
-                "oxAttributes",
-                "oxAuthAppType",
-                "oxLastLogonTime",
-                "oxDisabled",
-                "oxIncludeClaimsInIdToken",
-                "oxRptAsJwt",
-                "displayName",
-                "oxAuthClientSecret",
-                "oxAuthSubjectType",
+
+    def test_if_add_op_is_callable(self):
+        self.assertTrue(callable(op.Op.add_op),
+            'add_op is not callable')
+
+
+    def test_if_add_op_receives_needed_args(self):
+        needed_args = [
+            "self",
+            "displayName",
+            "oxAuthLogoutSessionRequired",
+            "oxAuthTrustedClient",
+            "oxAuthResponseType",
+            "oxAuthTokenEndpointAuthMethod",
+            "oxAuthRequireAuthTime",
+            "oxAccessTokenAsJwt",
+            "oxPersistClientAuthorizations",
+            "oxAuthGrantType",
+            "oxAttributes",
+            "oxAuthAppType",
+            "oxIncludeClaimsInIdToken",
+            "oxRptAsJwt",
+            "oxAuthClientSecret",
+            "oxAuthSubjectType",
+            "oxDisabled",
             ]
+        method_args = inspect.getfullargspec(op.Op.add_op).args
+        self.assertListEqual(needed_args,method_args)
 
-            # import ipdb; ipdb.set_trace()
-            self.assertTrue(
-                set(some_keys).issubset(tp[1]),
-                "search response[1] tuple does not have expected keys",
-            )
+
+    def test_if_add_op_returns_tuple(self):
+        self.assertTrue( type(self.op_instance.add_op(**helper.ADD_OP_TEST_ARGS)) is tuple,
+            'add_op does not return a tuple')
+
+
+    def test_if_add_op_returns_valid_op_attrs(self):
+        valid_keys = []
+        for key in helper.MOCKED_SEARCH_S_VALID_RESPONSE[0][1]:
+            valid_keys.append(key)
+
+        attrs = self.op_instance.add_op(**helper.ADD_OP_TEST_ARGS)[1]
+        self.assertTrue(
+            set(valid_keys).issubset(attrs),
+            "add_op returning attrs do not have expected keys",
+        )
+
+
+    def test_if_add_op_calls_add_modlist_with_args(self):
+
+        with patch.object(
+                ldaphelper.ldapconnector.modlist,
+                'addModlist') as addModlist:
+
+            self.op_instance.add_op(**helper.ADD_OP_TEST_ARGS)
+            all_attrs = {'displayName': b'test-client2', 'oxAuthLogoutSessionRequired': b'false',
+            'oxAuthTrustedClient': b'false', 'oxAuthResponseType': b'token',
+            'oxAuthTokenEndpointAuthMethod': b'client_secret_basic', 'oxAuthRequireAuthTime': b'false',
+            'oxAccessTokenAsJwt': b'false', 'oxPersistClientAuthorizations': b'true',
+            'oxAuthGrantType': b'client_credentials',
+            'oxAttributes': b'{"tlsClientAuthSubjectDn":null,"runIntrospectionScriptBeforeAccessTokenAsJwtCreationAndIncludeClaims":false,"keepClientAuthorizationAfterExpiration":false}',
+            'oxAuthAppType': b'web', 'oxIncludeClaimsInIdToken': b'false', 'oxRptAsJwt': b'false',
+            'oxAuthClientSecret': b'somecoolsecret', 'oxAuthSubjectType': b'pairwise',
+            'oxDisabled': b'false',
+            'objectClass': [b'top', b'oxAuthClient'],
+            'oxAuthScope': [b'inum=F0C4,ou=scopes,o=gluu', b'inum=C4F5,ou=scopes,o=gluu'], 'inum': b'w124asdgggAGs'}
+
+            addModlist.assert_called_once_with(all_attrs)
+
+
+    def test_if_add_op_calls_ldap_add_s(self):
+
+        with self.add_s as add_s:
+
+            self.op_instance.add_op(**helper.ADD_OP_TEST_ARGS)
+
+            add_s.assert_called_once_with('inum=w124asdgggAGs,ou=clients,o=gluu',
+                [('displayName', b'test-client2'), ('oxAuthLogoutSessionRequired', b'false'),
+                ('oxAuthTrustedClient', b'false'), ('oxAuthResponseType', b'token'),
+                ('oxAuthTokenEndpointAuthMethod', b'client_secret_basic'), ('oxAuthRequireAuthTime', b'false'),
+                ('oxAccessTokenAsJwt', b'false'), ('oxPersistClientAuthorizations', b'true'),
+                ('oxAuthGrantType', b'client_credentials'),
+                ('oxAttributes', b'{"tlsClientAuthSubjectDn":null,"runIntrospectionScriptBeforeAccessTokenAsJwtCreationAndIncludeClaims":false,"keepClientAuthorizationAfterExpiration":false}'),
+                ('oxAuthAppType', b'web'),
+                ('oxIncludeClaimsInIdToken', b'false'),
+                ('oxRptAsJwt', b'false'),
+                ('oxAuthClientSecret', b'somecoolsecret'),
+                ('oxAuthSubjectType', b'pairwise'),
+                ('oxDisabled', b'false'), ('objectClass', [b'top', b'oxAuthClient']),
+                ('oxAuthScope', [b'inum=F0C4,ou=scopes,o=gluu', b'inum=C4F5,ou=scopes,o=gluu']), ('inum', b'w124asdgggAGs')])
+        # restarting
+        self.add_s.start()
+
+
+    def test_add_op_should_return_created_op(self):
+        expected_created_op = ('inum=59376804-e84b-411a-9492-653d14e52c24,ou=clients,o=gluu', {'objectClass': [b'top', b'oxAuthClient'], 'oxAuthLogoutSessionRequired': [b'false'], 'oxAuthScope': [b'inum=F0C4,ou=scopes,o=gluu', b'inum=C4F5,ou=scopes,o=gluu'], 'oxAuthTrustedClient': [b'false'], 'oxAuthResponseType': [b'token'], 'oxAuthTokenEndpointAuthMethod': [b'client_secret_basic'], 'oxAuthRequireAuthTime': [b'false'], 'oxAccessTokenAsJwt': [b'false'], 'oxPersistClientAuthorizations': [b'true'], 'oxAuthGrantType': [b'client_credentials'], 'inum': [b'59376804-e84b-411a-9492-653d14e52c24'], 'oxAttributes': [b'{"tlsClientAuthSubjectDn":null,"runIntrospectionScriptBeforeAccessTokenAsJwtCreationAndIncludeClaims":false,"keepClientAuthorizationAfterExpiration":false}'], 'oxAuthAppType': [b'web'], 'oxLastLogonTime': [b'20200714072830.011Z'], 'oxAuthClientSecretExpiresAt': [b'21200623000000.000Z'], 'oxDisabled': [b'false'], 'oxIncludeClaimsInIdToken': [b'false'], 'oxRptAsJwt': [b'false'], 'displayName': [b'test-client'], 'oxAuthClientSecret': [b'gWxnjnUdCm8Rpc0WPmm9lQ=='], 'oxAuthSubjectType': [b'pairwise'], 'oxLastAccessTime': [b'20200714072830.011Z']})
+        self.assertEqual(
+            self.op_instance.add_op(**helper.ADD_OP_TEST_ARGS),
+            expected_created_op,
+            'add_op() is not returning created_op'
+        )
+
+

--- a/tests/test_op.py
+++ b/tests/test_op.py
@@ -77,7 +77,8 @@ class TestOp(TestCase):
         with patch.object(
                 op_instance.connection.connect,
                 "search_s",
-                return_value=helper.MOCKED_SEARCH_S_VALID_RESPONSE):
+                return_value=helper.MOCKED_SEARCH_S_VALID_RESPONSE,
+        ):
 
             self.assertIsInstance(
                 op.Op.get_op_by_display_name(op_instance, "test-client"),
@@ -98,7 +99,8 @@ class TestOp(TestCase):
         with patch.object(
                 op_instance.connection.connect,
                 "search_s",
-                return_value=helper.MOCKED_SEARCH_S_VALID_RESPONSE):
+                return_value=helper.MOCKED_SEARCH_S_VALID_RESPONSE,
+        ):
             op_client = op_instance.get_op_by_display_name("test-client")
             self.assertTrue(
                 type(op_client[1]) is dict,
@@ -109,8 +111,8 @@ class TestOp(TestCase):
         with patch.object(
                 op_instance.connection.connect,
                 "search_s",
-                return_value=helper.MOCKED_SEARCH_S_VALID_RESPONSE):
-
+                return_value=helper.MOCKED_SEARCH_S_VALID_RESPONSE,
+        ):
 
             tp = op_instance.get_op_by_display_name("test-client")
 

--- a/tests/test_op.py
+++ b/tests/test_op.py
@@ -5,8 +5,7 @@ from ldaphelper import op
 from types import ModuleType
 import inspect
 import ldap
-
-ldap.initialize
+import helper
 
 
 # helper

--- a/tests/test_op.py
+++ b/tests/test_op.py
@@ -13,12 +13,7 @@ def get_Op_instance():
     """ Returns Op instance initialized with a mocked LdapConnection """
     connection = MagicMock(ldaphelper.ldapconnector.LdapConnector)
     connection.__setattr__("connect", ldap.ldapobject.SimpleLDAPObject)
-    # connection.connect.__setattr__('search_s','value')
-    # connection.connect = MagicMock(ldaphelper.ldapconnector.LdapConnector.connect)
-    # connection.searchScope = MagicMock(ldaphelper.ldapconnector.LdapConnector.searchScope)
     op_instance = op.Op(connection)
-    # op_instance.connection.connect.search_s = MagicMock(
-    #     op.Op.dn,ldaphelper.LdapConnector.searchScope,'displayName=%s' % 'test-client')
     return op_instance
 
 
@@ -34,7 +29,7 @@ class TestOp(TestCase):
         self.assertTrue(hasattr(op, "Op"), "Op does not exist in op")
 
     def test_if_Op_is_class(self):
-        self.assertTrue(type(op.Op) == type, "Op is not type (not a Class)")
+        self.assertTrue(type(op.Op) is type, "Op is not type (not a Class)")
 
     def test_if_Op_receives_LdapConnector(self):
         """[Check if Op receives class LdapConnector as arg]
@@ -82,8 +77,8 @@ class TestOp(TestCase):
         with patch.object(
                 op_instance.connection.connect,
                 "search_s",
-                return_value=(helper.MOCKED_SEARCH_S_VALID_RESPONSE),
-        ) as search_s:
+                return_value=helper.MOCKED_SEARCH_S_VALID_RESPONSE):
+
             self.assertIsInstance(
                 op.Op.get_op_by_display_name(op_instance, "test-client"),
                 tuple,
@@ -94,7 +89,7 @@ class TestOp(TestCase):
         self.assertTrue(hasattr(op.Op, "dn"), "Op does not have dn attribute")
 
     def test_if_dn_is_string(self):
-        self.assertTrue(type(op.Op.dn) == str, "dn is not a string")
+        self.assertTrue(type(op.Op.dn) is str, "dn is not a string")
 
     def test_if_get_op_by_display_name_one_return_dict(self):
         """ get_op_by_display_name[1] """
@@ -103,11 +98,10 @@ class TestOp(TestCase):
         with patch.object(
                 op_instance.connection.connect,
                 "search_s",
-                return_value=(helper.MOCKED_SEARCH_S_VALID_RESPONSE),
-        ) as search_s:
+                return_value=helper.MOCKED_SEARCH_S_VALID_RESPONSE):
             op_client = op_instance.get_op_by_display_name("test-client")
             self.assertTrue(
-                type(op_client[1]) == dict,
+                type(op_client[1]) is dict,
                 "get_op_by_display_name[1] is not a dict")
 
     def test_if_get_op_by_display_name_returns_valid_tuple(self):
@@ -115,8 +109,8 @@ class TestOp(TestCase):
         with patch.object(
                 op_instance.connection.connect,
                 "search_s",
-                return_value=(helper.MOCKED_SEARCH_S_VALID_RESPONSE),
-        ) as search_s:
+                return_value=helper.MOCKED_SEARCH_S_VALID_RESPONSE):
+
 
             tp = op_instance.get_op_by_display_name("test-client")
 

--- a/tests/test_op.py
+++ b/tests/test_op.py
@@ -1,0 +1,134 @@
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+import ldaphelper
+from ldaphelper import op
+from types import ModuleType
+import inspect
+import ldap
+
+ldap.initialize
+
+# helper
+def get_Op_instance():
+    """ Returns Op instance initialized with a mocked LdapConnection """
+    connection = MagicMock(ldaphelper.ldapconnector.LdapConnector)
+    connection.__setattr__('connect',ldap.ldapobject.SimpleLDAPObject)
+    #connection.connect.__setattr__('search_s','value')
+    # connection.connect = MagicMock(ldaphelper.ldapconnector.LdapConnector.connect)
+    #connection.searchScope = MagicMock(ldaphelper.ldapconnector.LdapConnector.searchScope)
+    op_instance = op.Op(connection)
+    # op_instance.connection.connect.search_s = MagicMock(
+    #     op.Op.dn,ldaphelper.LdapConnector.searchScope,'displayName=%s' % 'test-client')
+    return op_instance
+
+
+class TestOp(TestCase):
+
+    def test_should_return_if_op_exists(self):
+        self.assertTrue(
+            hasattr(ldaphelper, 'op'),
+            'ldaphelper does not have op attribute'
+        )
+
+    def test_if_op_is_module(self):
+        self.assertIsInstance(
+            op,
+            ModuleType,
+            'op is not a module'
+        )
+
+    def test_if_Op_exists(self):
+        self.assertTrue(
+            hasattr(op, 'Op'),
+            'Op does not exist in op'
+        )
+
+    def test_if_Op_is_class(self):
+        self.assertTrue(
+            type(op.Op) == type,
+            'Op is not type (not a Class)'
+        )
+
+    def test_if_Op_receives_LdapConnector(self):
+        """[Check if Op receives class LdapConnector as arg]
+        """
+        annotations = inspect.getfullargspec(op.Op).annotations
+        annotations_values = []
+        for key in annotations:
+            annotations_values.append(annotations[key])
+        self.assertIn(
+            ldaphelper.ldapconnector.LdapConnector,
+            annotations_values,
+            'Op does not receive LdapConnector class as arg'
+        )
+
+
+    def test_if_Op_has_attr_connection(self):
+        self.assertTrue(hasattr(op.Op,'connection'),
+        'Op has no attribute named connection')
+
+    def test_if_connection_is_none(self):
+        self.assertIsNone(op.Op.connection, 'connection is not none')
+
+    def test_if_init_Op_connection_sets_LdapConnector_instance(self):
+        # import ipdb; ipdb.set_trace()
+        op_instance = get_Op_instance()
+
+        self.assertIsInstance(
+            op_instance.connection,
+            ldaphelper.ldapconnector.LdapConnector,
+            'connection is not an instance of LdapConnector after __init__'
+        )
+
+    def test_if_get_op_by_display_name_exists_in_Op(self):
+        self.assertTrue(hasattr(op.Op, 'get_op_by_display_name'))
+
+    def test_if_get_op_by_display_name_is_callable(self):
+        self.assertTrue(hasattr(op.Op.get_op_by_display_name, '__call__'),
+            'get_op_by_display_name is not callable')
+
+    # @patch.object(ldaphelper.LdapConnector.connect, 'search_s')
+    def test_get_op_by_display_name_should_return_a_tuple(self):
+
+        op_instance = get_Op_instance()
+        with patch.object(op_instance.connection.connect, 'search_s',
+            return_value = (('aaa','ddd'),)) as search_s:
+            """ @TODO: change return_value to mocked real response """
+
+            self.assertIsInstance(
+                op.Op.get_op_by_display_name(op_instance,'test-client'),
+                tuple,
+                'get_op_by_display_name() does not return a list'
+            )
+
+    def test_if_Op_has_dn(self):
+        self.assertTrue(hasattr(op.Op, 'dn'),
+        'Op does not have dn attribute')
+
+    def test_if_dn_is_string(self):
+        self.assertTrue( type(op.Op.dn) == str,
+        'dn is not a string')
+
+    def test_if_get_op_by_display_name_one_return_dict(self):
+        """ get_op_by_display_name[1] """
+        connection = ldaphelper.LdapConnector('cn=directory manager','Test123$')
+        oprovider = op.Op(connection)
+        tp = oprovider.get_op_by_display_name('test-client')
+        self.assertTrue(type(tp[1]) == dict,'get_op_by_display_name[1] is not a dict')
+
+    def test_if_get_op_by_display_name_returns_valid_tuple(self):
+        connection = ldaphelper.LdapConnector('cn=directory manager','Test123$')
+        oprovider = op.Op(connection)
+        tp = oprovider.get_op_by_display_name('test-client')
+
+        some_keys = ['objectClass', 'oxAuthScope', 'oxAuthTrustedClient', 'oxAuthResponseType',
+            'oxAuthTokenEndpointAuthMethod', 'oxAuthRequireAuthTime', 'oxAccessTokenAsJwt',
+            'oxPersistClientAuthorizations', 'oxAuthGrantType', 'inum', 'oxAttributes', 'oxAuthAppType',
+            'oxLastLogonTime', 'oxDisabled', 'oxIncludeClaimsInIdToken', 'oxRptAsJwt', 'displayName',
+            'oxAuthClientSecret', 'oxAuthSubjectType']
+        #import ipdb; ipdb.set_trace()
+        self.assertTrue(set(some_keys).issubset(tp[1]),'search response tuple does not have expected keys')
+
+
+
+

--- a/tests/test_op.py
+++ b/tests/test_op.py
@@ -9,14 +9,15 @@ import helper
 
 ldap.initialize
 
+
 # helper
 def get_Op_instance():
     """ Returns Op instance initialized with a mocked LdapConnection """
     connection = MagicMock(ldaphelper.ldapconnector.LdapConnector)
-    connection.__setattr__('connect',ldap.ldapobject.SimpleLDAPObject)
-    #connection.connect.__setattr__('search_s','value')
+    connection.__setattr__("connect", ldap.ldapobject.SimpleLDAPObject)
+    # connection.connect.__setattr__('search_s','value')
     # connection.connect = MagicMock(ldaphelper.ldapconnector.LdapConnector.connect)
-    #connection.searchScope = MagicMock(ldaphelper.ldapconnector.LdapConnector.searchScope)
+    # connection.searchScope = MagicMock(ldaphelper.ldapconnector.LdapConnector.searchScope)
     op_instance = op.Op(connection)
     # op_instance.connection.connect.search_s = MagicMock(
     #     op.Op.dn,ldaphelper.LdapConnector.searchScope,'displayName=%s' % 'test-client')
@@ -24,31 +25,18 @@ def get_Op_instance():
 
 
 class TestOp(TestCase):
-
     def test_should_return_if_op_exists(self):
-        self.assertTrue(
-            hasattr(ldaphelper, 'op'),
-            'ldaphelper does not have op attribute'
-        )
+        self.assertTrue(hasattr(ldaphelper, "op"),
+                        "ldaphelper does not have op attribute")
 
     def test_if_op_is_module(self):
-        self.assertIsInstance(
-            op,
-            ModuleType,
-            'op is not a module'
-        )
+        self.assertIsInstance(op, ModuleType, "op is not a module")
 
     def test_if_Op_exists(self):
-        self.assertTrue(
-            hasattr(op, 'Op'),
-            'Op does not exist in op'
-        )
+        self.assertTrue(hasattr(op, "Op"), "Op does not exist in op")
 
     def test_if_Op_is_class(self):
-        self.assertTrue(
-            type(op.Op) == type,
-            'Op is not type (not a Class)'
-        )
+        self.assertTrue(type(op.Op) == type, "Op is not type (not a Class)")
 
     def test_if_Op_receives_LdapConnector(self):
         """[Check if Op receives class LdapConnector as arg]
@@ -60,16 +48,15 @@ class TestOp(TestCase):
         self.assertIn(
             ldaphelper.ldapconnector.LdapConnector,
             annotations_values,
-            'Op does not receive LdapConnector class as arg'
+            "Op does not receive LdapConnector class as arg",
         )
 
-
     def test_if_Op_has_attr_connection(self):
-        self.assertTrue(hasattr(op.Op,'connection'),
-        'Op has no attribute named connection')
+        self.assertTrue(hasattr(op.Op, "connection"),
+                        "Op has no attribute named connection")
 
     def test_if_connection_is_none(self):
-        self.assertIsNone(op.Op.connection, 'connection is not none')
+        self.assertIsNone(op.Op.connection, "connection is not none")
 
     def test_if_init_Op_connection_sets_LdapConnector_instance(self):
         # import ipdb; ipdb.set_trace()
@@ -78,61 +65,87 @@ class TestOp(TestCase):
         self.assertIsInstance(
             op_instance.connection,
             ldaphelper.ldapconnector.LdapConnector,
-            'connection is not an instance of LdapConnector after __init__'
+            "connection is not an instance of LdapConnector after __init__",
         )
 
     def test_if_get_op_by_display_name_exists_in_Op(self):
-        self.assertTrue(hasattr(op.Op, 'get_op_by_display_name'))
+        self.assertTrue(hasattr(op.Op, "get_op_by_display_name"))
 
     def test_if_get_op_by_display_name_is_callable(self):
-        self.assertTrue(hasattr(op.Op.get_op_by_display_name, '__call__'),
-            'get_op_by_display_name is not callable')
+        self.assertTrue(
+            hasattr(op.Op.get_op_by_display_name, "__call__"),
+            "get_op_by_display_name is not callable",
+        )
 
     # @patch.object(ldaphelper.LdapConnector.connect, 'search_s')
     def test_get_op_by_display_name_should_return_a_tuple(self):
 
         op_instance = get_Op_instance()
-        with patch.object(op_instance.connection.connect, 'search_s',
-            return_value = (helper.MOCKED_SEARCH_S_VALID_RESPONSE)) as search_s:
+        with patch.object(
+                op_instance.connection.connect,
+                "search_s",
+                return_value=(helper.MOCKED_SEARCH_S_VALID_RESPONSE),
+        ) as search_s:
             self.assertIsInstance(
-                op.Op.get_op_by_display_name(op_instance,'test-client'),
+                op.Op.get_op_by_display_name(op_instance, "test-client"),
                 tuple,
-                'get_op_by_display_name() does not return a list'
+                "get_op_by_display_name() does not return a list",
             )
 
     def test_if_Op_has_dn(self):
-        self.assertTrue(hasattr(op.Op, 'dn'),
-        'Op does not have dn attribute')
+        self.assertTrue(hasattr(op.Op, "dn"), "Op does not have dn attribute")
 
     def test_if_dn_is_string(self):
-        self.assertTrue( type(op.Op.dn) == str,
-        'dn is not a string')
+        self.assertTrue(type(op.Op.dn) == str, "dn is not a string")
 
     def test_if_get_op_by_display_name_one_return_dict(self):
         """ get_op_by_display_name[1] """
         # mocked
         op_instance = get_Op_instance()
-        with patch.object(op_instance.connection.connect, 'search_s',
-            return_value = (helper.MOCKED_SEARCH_S_VALID_RESPONSE)) as search_s:
-            op_client = op_instance.get_op_by_display_name('test-client')
-            self.assertTrue(type(op_client[1]) == dict,'get_op_by_display_name[1] is not a dict')
+        with patch.object(
+                op_instance.connection.connect,
+                "search_s",
+                return_value=(helper.MOCKED_SEARCH_S_VALID_RESPONSE),
+        ) as search_s:
+            op_client = op_instance.get_op_by_display_name("test-client")
+            self.assertTrue(
+                type(op_client[1]) == dict,
+                "get_op_by_display_name[1] is not a dict")
 
     def test_if_get_op_by_display_name_returns_valid_tuple(self):
         op_instance = get_Op_instance()
-        with patch.object(op_instance.connection.connect, 'search_s',
-            return_value = (helper.MOCKED_SEARCH_S_VALID_RESPONSE)) as search_s:
+        with patch.object(
+                op_instance.connection.connect,
+                "search_s",
+                return_value=(helper.MOCKED_SEARCH_S_VALID_RESPONSE),
+        ) as search_s:
 
-            tp = op_instance.get_op_by_display_name('test-client')
+            tp = op_instance.get_op_by_display_name("test-client")
 
-            some_keys = ['objectClass', 'oxAuthScope', 'oxAuthTrustedClient', 'oxAuthResponseType',
-                'oxAuthTokenEndpointAuthMethod', 'oxAuthRequireAuthTime', 'oxAccessTokenAsJwt',
-                'oxPersistClientAuthorizations', 'oxAuthGrantType', 'inum', 'oxAttributes', 'oxAuthAppType',
-                'oxLastLogonTime', 'oxDisabled', 'oxIncludeClaimsInIdToken', 'oxRptAsJwt', 'displayName',
-                'oxAuthClientSecret', 'oxAuthSubjectType']
+            some_keys = [
+                "objectClass",
+                "oxAuthScope",
+                "oxAuthTrustedClient",
+                "oxAuthResponseType",
+                "oxAuthTokenEndpointAuthMethod",
+                "oxAuthRequireAuthTime",
+                "oxAccessTokenAsJwt",
+                "oxPersistClientAuthorizations",
+                "oxAuthGrantType",
+                "inum",
+                "oxAttributes",
+                "oxAuthAppType",
+                "oxLastLogonTime",
+                "oxDisabled",
+                "oxIncludeClaimsInIdToken",
+                "oxRptAsJwt",
+                "displayName",
+                "oxAuthClientSecret",
+                "oxAuthSubjectType",
+            ]
 
-            #import ipdb; ipdb.set_trace()
-            self.assertTrue(set(some_keys).issubset(tp[1]),'search response[1] tuple does not have expected keys')
-
-
-
-
+            # import ipdb; ipdb.set_trace()
+            self.assertTrue(
+                set(some_keys).issubset(tp[1]),
+                "search response[1] tuple does not have expected keys",
+            )


### PR DESCRIPTION
get and create open-id clients on gluu

- Op class created, with get_op_by_display_name() and add_op() methods
- Tests: added helper, mocked when needed

Able to create and get openid clients from gluu ldap